### PR TITLE
Mejora en escalado

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -18,7 +18,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		});
 	})
 
-	$('#scale').addEventListener('change', (e) => {
+	$('#scale').addEventListener('input', (e) => {
 		const scale = e.target.value
 		ogtView.setAttribute('scale', scale);
 		$('#scale-value').innerText = scale;

--- a/assets/ogtscript.js
+++ b/assets/ogtscript.js
@@ -25,7 +25,7 @@ class OGTScript {
     else {
       this.options = {
         scale: 1,
-        autoSize: false
+        autoSize: true
       }
     }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,4 +1,6 @@
-#drawer {
+.view-example {
+	display: grid;
+	place-content: center;
 	width: 256px;
 	height: 256px;
 }

--- a/assets/tag-ver-ogt.js
+++ b/assets/tag-ver-ogt.js
@@ -28,7 +28,7 @@ class VerOGT extends HTMLElement {
 
   // Esta es la función que contiene la plantilla con el visor y en un futuro el editor
   get template() {
-    return `<canvas id="drawer" width="256" height="256"></canvas>`
+    return `<canvas id="drawer"></canvas>`
   }
 
   // Esta función se llama cada vez que se cambia una propiedad de la etiqueta del componente

--- a/index.html
+++ b/index.html
@@ -23,14 +23,13 @@
 				<input type="radio" name="src" class="cambiar-src" value="example.ogt">
 				src="example.ogt"
 			</label>
-			<div id="div-scale">
-				Escala de la imagen: scale="<span id="scale-value">1</span>"
-				<input type="range" id="scale" name="scale" 
-					min="1" max="10" value="1">
-			</div>
 		</div>
 		<div class="view-example">
-			<ver-ogt scale="2"></ver-ogt>
+			<ver-ogt auto-size="1" />
+		</div>
+		<div id="div-scale">
+			Escala de la imagen (x<span id="scale-value">1</span>)
+			<input type="range" id="scale" name="scale" min="1" max="8" value="1">
 		</div>
 	</div>
 	<canvas id="test"></canvas>


### PR DESCRIPTION
¡Hola!

Existe un pequeño corte con escalas superiores a 8:

![image](https://github.com/son-link/ogtscript/assets/4882454/547f6999-318c-485a-8fb7-bc6604213da9)

Por ello, esta PR limita _scale_ a x8, dejando máx. tamaño 256x256. Se aprovecha para centrar el OGT y usar el evento "input" para el _range_ y se refleje a tiempo real:

![CPT2305312112-502x461](https://github.com/son-link/ogtscript/assets/4882454/802cb563-cf5f-4c8e-9db1-1f37a05174b3)

Un placer contribuir por aquí
*jart*